### PR TITLE
Use legacy yum group commands to support earlier yum versions

### DIFF
--- a/lib/puppet/provider/package/yum_group.rb
+++ b/lib/puppet/provider/package/yum_group.rb
@@ -17,17 +17,17 @@ Puppet::Type.type(:package).provide :yum_group, :parent => :rpm, :source => :rpm
 
 
   def install
-    execute([command(:cmd), "-y", "group", "install", @resource[:name]])
+    execute([command(:cmd), "-y", "groupinstall", @resource[:name]])
   end
 
 
   def uninstall
-    execute([command(:cmd), "-y", "group", "remove", @resource[:name]])
+    execute([command(:cmd), "-y", "groupremove", @resource[:name]])
   end
 
 
   def self.instances
-    yum_groups = execute([command(:cmd), "group", "list", "installed", "-q"])
+    yum_groups = execute([command(:cmd), "grouplist", "installed", "-q"])
 
     # returns a Puppet::Util::Execution::ProcessOutput which is a kinda magic
     # string-like thing thats not really a string and is also a private API. for

--- a/metadata.json
+++ b/metadata.json
@@ -13,6 +13,22 @@
       "version_requirement": ">= 1.0.0"
     }
   ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+          "7",
+          "6"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+          "7",
+          "6"
+      ]
+    }
+  ],
   "data_provider": null,
   "project_url": "https://github.com/GeoffWilliams/puppet-package_yum_group.git"
 }


### PR DESCRIPTION
This means this provider should work out of the box for CentOS 6.

I have not run the `pdq` unit tests since, as far as I could tell, there were no useful tests and I didn't have time to set up ruby & bundler. 
I'd be happy to run unit tests if you'd be willing to switch this module to be PDK compatible as that makes it very easy to run these tests :)

Fixes #1